### PR TITLE
use gopkgs if possible to get packages faster

### DIFF
--- a/autoload/unite/sources/go_import.vim
+++ b/autoload/unite/sources/go_import.vim
@@ -41,6 +41,11 @@ else
 endif
 
 function! s:go_packages() abort
+    if executable('gopkgs')
+      " https://github.com/haya14busa/gopkgs
+      return split(system('gopkgs'), "\n")
+    endif
+
     let dirs = []
 
     if executable('go')


### PR DESCRIPTION
Hi, I created https://github.com/haya14busa/gopkgs which list all go packages fast by using the same implementation as [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports).

In my environment ($GOPATH/src has 725045 files...), `:Unite go/import` is slow for daily use, but by introducing `gopkgs`, it takes just a sec.

Can you consider to include it?

I'll add some note for `gopkgs` in README or document if you want.

Thanks
